### PR TITLE
Linting and code cleanup

### DIFF
--- a/lab4.py
+++ b/lab4.py
@@ -4,9 +4,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # Kangerlussuaq average temperature:
-t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
+t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7,
+                     8.5, 3.1, -6.0, -12.0, -16.9])
+
 # Correct temperature values for the heat equation to validate against:
-correct = np.array([[0.000000, 0.640000, 0.960000, 0.960000, 0.640000, 0.000000],
+correct = np.array([
+    [0.000000, 0.640000, 0.960000, 0.960000, 0.640000, 0.000000],
     [0.000000, 0.480000, 0.800000, 0.800000, 0.480000, 0.000000],
     [0.000000, 0.400000, 0.640000, 0.640000, 0.400000, 0.000000],
     [0.000000, 0.320000, 0.520000, 0.520000, 0.320000, 0.000000],
@@ -19,16 +22,20 @@ correct = np.array([[0.000000, 0.640000, 0.960000, 0.960000, 0.640000, 0.000000]
     [0.000000, 0.072812, 0.117813, 0.117813, 0.072812, 0.000000]])
 correct = correct.transpose()
 
+
 def sample_init(x):
     '''Simple initial boundary condition function'''
     return 4*x - 4*x**2
-def fwddiff_neumann(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init):
+
+
+def fwddiff_neumann(dt=0.02, dx=0.2, c2=1.0, xmax=1.0,
+                    tmax=0.2, init=sample_init):
     '''
     Neumann Forward difference solver.
 
     Parameters
     ----------
-    dt, dx : float, default=0.02, 0.2 
+    dt, dx : float, default=0.02, 0.2
         Time and space step.
     c2 : float, default=1.0
         Thermal diffusivity.
@@ -46,7 +53,7 @@ def fwddiff_neumann(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init
         Array of time points/y-grid
     temp : numpy 2D array
         Temperature as a function of time and space.
-    
+
     '''
 
     # Set constants:
@@ -55,7 +62,7 @@ def fwddiff_neumann(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init
     # Create space and time grids
     x = np.arange(0, xmax+dx, dx)
     t = np.arange(0, tmax+dt, dt)
-    
+
     # Save number of points.
     M, N = x.size, t.size
 
@@ -68,24 +75,29 @@ def fwddiff_neumann(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init
     else:
         temp[:, 0] = init
 
-
     # Solve!
     for j in range(0, N-1):
-        temp[1:-1, j+1] = (1-2*r)*temp[1:-1, j] + r*(temp[2:, j] + temp[:-2, j])
-        temp[0, j+1] = temp[1,j+1]
+        temp[1:-1, j+1] = (1-2*r)*temp[1:-1, j] + \
+            r*(temp[2:, j] + temp[:-2, j])
+        temp[0, j+1] = temp[1, j+1]
         temp[-1, j+1] = temp[-2, j+1]
 
     return x, t, temp
-def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bound=0.0,min_bound=0.0,xmin=0.0,tmin=0.0):
+
+
+def fwddiff(dt=0.02, dx=0.2, c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,
+            max_bound=0.0, min_bound=0.0, xmin=0.0, tmin=0.0):
     '''
-    Forward difference solver. Taking in a subset of the time step, x step, thermal diffusivity, maximum x value, maximum time, and initializing and boundary
-    functions/values, minimum value of x, and minimum value of t,
-    this function will either generate and return the x array, time array, and temperature array (if the solution is numerically stable)
-    or it will return a tuple of -1 values (if the solution is not stable.) 
+    Forward difference solver. Taking in a subset of the time step, x step,
+    thermal diffusivity, maximum x value, maximum time, and initializing and
+    boundary functions/values, minimum value of x, and minimum value of t,
+    this function will either generate and return the x array, time array, and
+    temperature array (if the solution is numerically stable)
+    or it will return a tuple of -1 values (if the solution is not stable.)
 
     Parameters
     ----------
-    dt, dx : float, default=0.02, 0.2 
+    dt, dx : float, default=0.02, 0.2
         Time and space step.
     c2 : float, default=1.0
         Thermal diffusivity.
@@ -93,8 +105,9 @@ def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bou
     xmax, tmax : float, default=1.0, 0.2
         Set max values for space and time grids
     init, max_bound, min_bound : scalar or function
-        Set initial condition and boundary conditions. If functions, should take position
-        as an input and return temperature using same units as x, temp.
+        Set initial condition and boundary conditions. If functions,
+        should take position as an input and return temperature using same
+        units as x, temp.
     xmin: float, default = 0.0
         Initial minimum value for the space grid
     tmin: float, default = 0.0
@@ -107,7 +120,7 @@ def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bou
         Array of time points/y-grid
     temp : numpy 2D array
         Temperature as a function of time and space.
-    
+
     '''
     # Check for instability
     if dt > (dx ** 2)/(2*c2):
@@ -118,7 +131,7 @@ def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bou
     # Create space and time grids
     x = np.arange(xmin, xmax+dx, dx)
     t = np.arange(tmin, tmax+dt, dt)
-    
+
     # Save number of points.
     M, N = x.size, t.size
 
@@ -131,7 +144,7 @@ def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bou
     else:
         temp[0, :] = min_bound
     if callable(max_bound):
-        temp[-1,:] = max_bound(t)
+        temp[-1, :] = max_bound(t)
     else:
         temp[-1, :] = max_bound
     # Set initial condition.
@@ -140,27 +153,34 @@ def fwddiff(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bou
     else:
         temp[:, 0] = init
 
-
     # Solve!
     for j in range(0, N-1):
-        temp[1:-1, j+1] = (1-2*r)*temp[1:-1, j] + r*(temp[2:, j] + temp[:-2, j])
+        temp[1:-1, j+1] = (1-2*r)*temp[1:-1, j] + \
+            r*(temp[2:, j] + temp[:-2, j])
 
     return x, t, temp
 
-def gen_heatmap(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bound=0.0,min_bound=0.0,xmin=0.0,tmin=0.0):
+
+def gen_heatmap(dt=0.02, dx=0.2, c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,
+                max_bound=0.0, min_bound=0.0, xmin=0.0, tmin=0.0):
     '''
-    Generates the heatmap for a given dt, dx, c^2, xmax, tmax, xmin, tmin, and initial and boundary conditions. Does this by running the forward difference solver with these values and then using
-    matplotlib's pcolor and colorbar functions. This function instead simply returns -1 if the given conditions are numerically unstable.
+    Generates the heatmap for a given dt, dx, c^2, xmax, tmax, xmin, tmin, and
+    initial and boundary conditions. Does this by running the forward
+    difference solver with these values and then using matplotlib's pcolor and
+    colorbar functions. This function instead simply returns -1 if the given
+    conditions are numerically unstable.
     '''
-    #Get solution using the forward-difference solver:
-    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, xmax=xmax, tmax=tmax, init=init,max_bound=max_bound,min_bound=min_bound,xmin=xmin,tmin=tmin)
+    # Get solution using the forward-difference solver:
+    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, xmax=xmax, tmax=tmax,
+                            init=init, max_bound=max_bound,
+                            min_bound=min_bound, xmin=xmin, tmin=tmin)
 
     # Check for instability.
-    if type(x)=="int" and type(time)=="int" and type(heat)=="int":
+    if type(x) is int and type(time) is int and type(heat) is int:
         return -1
 
     # Create a figure
-    fig, axes = plt.subplots(1, 1) 
+    fig, axes = plt.subplots(1, 1)
 
     # Create a color map and add a color bar.
     map = axes.pcolor(time/365, x, heat, cmap='seismic', vmin=-25, vmax=25)
@@ -169,19 +189,26 @@ def gen_heatmap(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max
     axes.set_ylabel('Height (m)')
     return fig, axes
 
-def gengroundprof(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,max_bound=0.0,min_bound=0.0,xmin=0.0,tmin=0.0):
+
+def gengroundprof(dt=0.02, dx=0.2, c2=1.0, xmax=1.0, tmax=0.2,
+                  init=sample_init, max_bound=0.0, min_bound=0.0, xmin=0.0,
+                  tmin=0.0):
     '''
-    Generates the ground profile for a given dt, dx, c2, xmax, tmax, xmin, tmin, and initial and boundary conditions. Does this by running the forward difference solver with these values and then
-    finding the minimum values in the final year of the solution.
+    Generates the ground profile for a given dt, dx, c2, xmax, tmax, xmin,
+    tmin, and initial and boundary conditions. Does this by running the forward
+    difference solver with these values and then finding the minimum values in
+    the final year of the solution.
     '''
     # Get solution using the forward-difference solver:
-    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, xmax=xmax, tmax=tmax, init=init,max_bound=max_bound,min_bound=min_bound,xmin=xmin,tmin=tmin)
+    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, xmax=xmax, tmax=tmax,
+                            init=init, max_bound=max_bound,
+                            min_bound=min_bound, xmin=xmin, tmin=tmin)
 
     # Check for instability
-    if type(x)=="int" and type(time)=="int" and type(heat)=="int":
+    if type(x) is int and type(time) is int and type(heat) is int:
         return -1
     # Set indexing for the final year of results:
-    loc = int(-365/dt) # Final 365 days of the result.
+    loc = int(-365/dt)  # Final 365 days of the result.
     # Extract the min values over the final year:
     winter = heat[:, loc:].min(axis=1)
 
@@ -197,9 +224,11 @@ def gengroundprof(dt=0.02, dx=0.2,c2=1.0, xmax=1.0, tmax=0.2, init=sample_init,m
 
     return fig, ax2
 
+
 def temp_kanger(t):
     '''
-    For an array of times in days, return timeseries of temperature for Kangerlussuaq, Greenland.
+    For an array of times in days, return timeseries of temperature for
+    Kangerlussuaq, Greenland.
     Parameters
     ==========
     t: array
@@ -208,9 +237,11 @@ def temp_kanger(t):
     t_amp = (t_kanger - t_kanger.mean()).max()
     return t_amp * np.sin(np.pi/180 * t - np.pi/2) + t_kanger.mean()
 
+
 def check_correct(error):
     '''
-    Validates that the forward difference solver works for the check condition for a given error.
+    Validates that the forward difference solver works for the check condition
+    for a given error.
 
     Parameters
     ==========
@@ -224,10 +255,12 @@ def check_correct(error):
     within = (abs(fwddiff()[2] - correct) < 0.1).all()
     return within
 
+
 def check_unstable():
     '''
-    Validates that the forward difference solver quits if the solution is unstable.
-    
+    Validates that the forward difference solver quits if the solution
+    is unstable.
+
     Returns
     =======
     bad_sol: boolean
@@ -238,32 +271,38 @@ def check_unstable():
         dx = np.random.rand()
         c2 = np.random.rand()
         dt = ((dx ** 2) / (2*c2))+1
-        i, j, k = fwddiff(dt = dt, dx=dx, c2=c2)
-        if i!=-1 or j!=-1 or k!=-1:
+        i, j, k = fwddiff(dt=dt, dx=dx, c2=c2)
+        if i != -1 or j != -1 or k != -1:
             bad_sol = True
     return bad_sol
+
+
 def homework_problem():
     # Get solution using the forward-difference solver:
     x, time, heat = fwddiff(dt=0.0002, dx=0.02)
-    x1, time1, heat1 = fwddiff_neumann(dt=0.0002,dx=0.02)
+    x1, time1, heat1 = fwddiff_neumann(dt=0.0002, dx=0.02)
 
     # Create a figure
-    fig, axes = plt.subplots(2, 1) 
+    fig, axes = plt.subplots(2, 1)
 
     # Create a color map and add a color bar.
-    map = axes[0].pcolor(time, x, heat, cmap='seismic', vmin=-1, vmax=1,label='Dirichlet')
-    map2 = axes[1].pcolor(time1, x1, heat1, cmap='seismic', vmin=-1, vmax=1,label='Neumann')
+    map = axes[0].pcolor(time, x, heat, cmap='seismic', vmin=-1, vmax=1,
+                         label='Dirichlet')
+    map2 = axes[1].pcolor(time1, x1, heat1, cmap='seismic', vmin=-1,
+                          vmax=1, label='Neumann')
     plt.colorbar(map, ax=axes, label='Temperature ($C$)')
     axes[0].legend()
     axes[1].legend()
     plt.savefig('homework_problem')
+
 
 def prob_two():
     '''
     Solves problem 2 of the assignment.
     '''
     # Set the conditions
-    t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
+    t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4,
+                         10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
     xmax = 0.0
     xmin = -100.0
     max_bound = temp_kanger
@@ -275,12 +314,14 @@ def prob_two():
     steady = False
 
     # Find the number of years needed to reach steady state
-    
+
     while not steady:
-        x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax, max_bound=max_bound,min_bound=min_bound,xmin=xmin)
-        
+        x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax,
+                                tmax=tmax, max_bound=max_bound,
+                                min_bound=min_bound, xmin=xmin)
+
         # Set indexing for the final year of results:
-        loc = int(-365/dt) # Final 365 days of the result.
+        loc = int(-365/dt)  # Final 365 days of the result.
 
         # Extract the min values over the final year:
         winter = heat[:, loc:].min(axis=1)
@@ -289,36 +330,40 @@ def prob_two():
         summer = heat[:, loc:].max(axis=1)
 
         # Extract the min values over the penultimate year
-        winter2 = heat[:,2*loc:loc].min(axis=1)
+        winter2 = heat[:, 2*loc:loc].min(axis=1)
 
         # Extract the max values over the penultimate year
-        summer2 = heat[:,2*loc:loc].max(axis=1)
+        summer2 = heat[:, 2*loc:loc].max(axis=1)
 
         # Temporarily say we're in steady state, even if not true.
         steady = True
 
         for i in range(len(summer)):
             if abs(summer[i] - winter[i]) < 10:
-                if abs(summer[i] - summer2[i]) > 0.001 :
+                if abs(summer[i] - summer2[i]) > 0.001:
                     steady = False
 
         # Add on another year
         tmax += 365
 
     print("Years to stabilization: " + str(tmax/365))
-    fig, ax = gen_heatmap(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin) 
+    fig, ax = gen_heatmap(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                          max_bound=max_bound, min_bound=min_bound, xmin=xmin)
     ax.set_title('Heatmap Without Adjustment')
     fig.savefig('heatmap_prob_2')
-    fig2, ax2 = gengroundprof(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin)
+    fig2, ax2 = gengroundprof(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax,
+                              init=0, max_bound=max_bound, min_bound=min_bound,
+                              xmin=xmin)
     ax2.set_title('Ground Profile Without Adjustment')
     fig2.savefig('groundprof_prob_2')
 
-#Now, solve problem three of the assignment.
+# Now, solve problem three of the assignment.
 
 # First, add a uniform 0.5 temperature shift.
 
 # Set the conditions
-t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
+t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4,
+                     10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
 t_kanger = t_kanger + 0.5
 xmax = 0.0
 xmin = -100.0
@@ -331,12 +376,14 @@ dt = (dx**2)/(2*c2)
 steady = False
 
 # Find the number of years needed to reach steady state
-    
+
 while not steady:
-    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax, max_bound=max_bound,min_bound=min_bound,xmin=xmin)
-        
+    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax,
+                            max_bound=max_bound, min_bound=min_bound,
+                            xmin=xmin)
+
     # Set indexing for the final year of results:
-    loc = int(-365/dt) # Final 365 days of the result.
+    loc = int(-365/dt)  # Final 365 days of the result.
 
     # Extract the min values over the final year:
     winter = heat[:, loc:].min(axis=1)
@@ -345,33 +392,36 @@ while not steady:
     summer = heat[:, loc:].max(axis=1)
 
     # Extract the min values over the penultimate year
-    winter2 = heat[:,2*loc:loc].min(axis=1)
+    winter2 = heat[:, 2*loc:loc].min(axis=1)
 
     # Extract the max values over the penultimate year
-    summer2 = heat[:,2*loc:loc].max(axis=1)
+    summer2 = heat[:, 2*loc:loc].max(axis=1)
 
     # Temporarily say we're in steady state, even if not true.
     steady = True
 
     for i in range(len(summer)):
         if abs(summer[i] - winter[i]) < 10:
-            if abs(summer[i] - summer2[i]) > 0.001 :
+            if abs(summer[i] - summer2[i]) > 0.001:
                 steady = False
     # Add on another year
     tmax += 365
 
 print("Years to stabilization for a 0.5 shift: " + str(tmax/365))
-fig, ax = gen_heatmap(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin) 
+fig, ax = gen_heatmap(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                      max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax.set_title('Heatmap for a 0.5 degree Shift')
 fig.savefig('heatmap_prob_3_0_5')
-fig2, ax2 = gengroundprof(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin)
+fig2, ax2 = gengroundprof(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                          max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax2.set_title('Ground Profile for a 0.5 degree Shift')
 fig2.savefig('groundprof_prob_3_0_5')
 
 # Now, add a uniform 1 degree temperature shift.
 
 # Set the conditions
-t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
+t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7,
+                     8.5, 3.1, -6.0, -12.0, -16.9])
 t_kanger = t_kanger + 1
 xmax = 0.0
 xmin = -100.0
@@ -384,12 +434,14 @@ dt = (dx**2)/(2*c2)
 steady = False
 
 # Find the number of years needed to reach steady state
-    
+
 while not steady:
-    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax, max_bound=max_bound,min_bound=min_bound,xmin=xmin)
-        
+    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax,
+                            max_bound=max_bound, min_bound=min_bound,
+                            xmin=xmin)
+
     # Set indexing for the final year of results:
-    loc = int(-365/dt) # Final 365 days of the result.
+    loc = int(-365/dt)  # Final 365 days of the result.
 
     # Extract the min values over the final year:
     winter = heat[:, loc:].min(axis=1)
@@ -398,33 +450,36 @@ while not steady:
     summer = heat[:, loc:].max(axis=1)
 
     # Extract the min values over the penultimate year
-    winter2 = heat[:,2*loc:loc].min(axis=1)
+    winter2 = heat[:, 2*loc:loc].min(axis=1)
 
     # Extract the max values over the penultimate year
-    summer2 = heat[:,2*loc:loc].max(axis=1)
+    summer2 = heat[:, 2*loc:loc].max(axis=1)
 
     # Temporarily say we're in steady state, even if not true.
     steady = True
 
     for i in range(len(summer)):
         if abs(summer[i] - winter[i]) < 10:
-            if abs(summer[i] - summer2[i]) > 0.001 :
+            if abs(summer[i] - summer2[i]) > 0.001:
                 steady = False
     # Add on another year
     tmax += 365
 
 print("Years to stabilization for a 1 shift: " + str(tmax/365))
-fig, ax = gen_heatmap(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin) 
+fig, ax = gen_heatmap(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                      max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax.set_title('Heatmap for a 1 degree Shift')
 fig.savefig('heatmap_prob_3_1')
-fig2,ax2 = gengroundprof(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin)
+fig2, ax2 = gengroundprof(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                          max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax2.set_title('Ground Profile for a 1 degree Shift')
 fig2.savefig('groundprof_prob_3_1')
 
 # Finally, add a uniform 3 degree temperature shift.
 
 # Set the conditions
-t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7, 8.5, 3.1, -6.0, -12.0, -16.9])
+t_kanger = np.array([-19.7, -21.0, -17., -8.4, 2.3, 8.4, 10.7,
+                     8.5, 3.1, -6.0, -12.0, -16.9])
 t_kanger = t_kanger + 3
 xmax = 0.0
 xmin = -100.0
@@ -437,12 +492,14 @@ dt = (dx**2)/(2*c2)
 steady = False
 
 # Find the number of years needed to reach steady state
-    
+
 while not steady:
-    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax, max_bound=max_bound,min_bound=min_bound,xmin=xmin)
-        
+    x, time, heat = fwddiff(dt=dt, dx=dx, c2=c2, init=0, xmax=xmax, tmax=tmax,
+                            max_bound=max_bound, min_bound=min_bound,
+                            xmin=xmin)
+
     # Set indexing for the final year of results:
-    loc = int(-365/dt) # Final 365 days of the result.
+    loc = int(-365/dt)  # Final 365 days of the result.
 
     # Extract the min values over the final year:
     winter = heat[:, loc:].min(axis=1)
@@ -451,25 +508,27 @@ while not steady:
     summer = heat[:, loc:].max(axis=1)
 
     # Extract the min values over the penultimate year
-    winter2 = heat[:,2*loc:loc].min(axis=1)
+    winter2 = heat[:, 2*loc:loc].min(axis=1)
 
     # Extract the max values over the penultimate year
-    summer2 = heat[:,2*loc:loc].max(axis=1)
+    summer2 = heat[:, 2*loc:loc].max(axis=1)
 
     # Temporarily say we're in steady state, even if not true.
     steady = True
 
     for i in range(len(summer)):
         if abs(summer[i] - winter[i]) < 10:
-            if abs(summer[i] - summer2[i]) > 0.001 :
+            if abs(summer[i] - summer2[i]) > 0.001:
                 steady = False
     # Add on another year
     tmax += 365
 
 print("Years to stabilization for a 3 shift: " + str(tmax/365))
-fig, ax = gen_heatmap(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin) 
+fig, ax = gen_heatmap(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                      max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax.set_title('Heatmap for a 3 degree Shift')
 fig.savefig('heatmap_prob_3_3')
-fig2, ax2 = gengroundprof(dx=dx,dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,max_bound=max_bound,min_bound=min_bound,xmin=xmin)
+fig2, ax2 = gengroundprof(dx=dx, dt=dt, c2=c2, xmax=xmax, tmax=tmax, init=0,
+                          max_bound=max_bound, min_bound=min_bound, xmin=xmin)
 ax2.set_title('Ground Profile for a 3 degree Shift')
 fig2.savefig('groundprof_prob_3_3')


### PR DESCRIPTION
Major linting pass to split (very) long lines into multiple lines, ad…d consistent spacing (e.g., after commas, etc), and fixing type comparisons.

Basically, I went through and applied PEP8 standards. PEP8 is a style guide for python formatting. While not required, it is widely used, and many repositories require it.

For this code, the big changes are wrapping very long lines around the 80-character mark. Having lines that go 200+ characters makes for code that is difficult to read.

Another small but functionally important change is how typing is performed:
`type(var) != 'int'` is being phased out, you should use "is": 
`type(var) is int` is the more accepted way to do things (and won't draw errors on future versions of Python.

Overall, very nice code that just needed a bit of linting. Some good functionality.